### PR TITLE
Support for parralel queries

### DIFF
--- a/src/archetype.rs
+++ b/src/archetype.rs
@@ -19,6 +19,7 @@ use crate::{
     bundle::DynamicBundle,
     component::{Component, ComponentInfo},
     entity::EntityId,
+    epoch::Epoch,
     idx::MAX_IDX_USIZE,
     typeidset::TypeIdSet,
 };
@@ -230,9 +231,9 @@ use crate::{
 #[derive(Debug)]
 pub(crate) struct ComponentData {
     pub ptr: NonNull<u8>,
-    pub version: UnsafeCell<u64>,
-    pub entity_versions: NonNull<u64>,
-    pub chunk_versions: NonNull<u64>,
+    pub version: UnsafeCell<Epoch>,
+    pub entity_versions: NonNull<Epoch>,
+    pub chunk_versions: NonNull<Epoch>,
     pub info: ComponentInfo,
 }
 
@@ -424,7 +425,7 @@ impl Archetype {
     /// Spawns new entity in the archetype.
     ///
     /// Returns index of the newly created entity in the archetype.
-    pub fn spawn<B>(&mut self, entity: EntityId, bundle: B, epoch: u64) -> u32
+    pub fn spawn<B>(&mut self, entity: EntityId, bundle: B, epoch: Epoch) -> u32
     where
         B: DynamicBundle,
     {
@@ -512,7 +513,7 @@ impl Archetype {
     /// # Safety
     ///
     /// Bundle must not contain components that are absent in this archetype.
-    pub unsafe fn set_bundle<B>(&mut self, idx: u32, bundle: B, epoch: u64)
+    pub unsafe fn set_bundle<B>(&mut self, idx: u32, bundle: B, epoch: Epoch)
     where
         B: DynamicBundle,
     {
@@ -528,7 +529,7 @@ impl Archetype {
     /// # Safety
     ///
     /// Archetype must contain that component type.
-    pub unsafe fn set<T>(&mut self, idx: u32, value: T, epoch: u64)
+    pub unsafe fn set<T>(&mut self, idx: u32, value: T, epoch: Epoch)
     where
         T: Component,
     {
@@ -552,7 +553,7 @@ impl Archetype {
         dst: &mut Archetype,
         src_idx: u32,
         bundle: B,
-        epoch: u64,
+        epoch: Epoch,
     ) -> (u32, Option<u32>)
     where
         B: DynamicBundle,
@@ -609,7 +610,7 @@ impl Archetype {
         dst: &mut Archetype,
         src_idx: u32,
         value: T,
-        epoch: u64,
+        epoch: Epoch,
     ) -> (u32, Option<u32>)
     where
         T: Component,
@@ -766,7 +767,7 @@ impl Archetype {
     }
 
     #[inline]
-    unsafe fn write_bundle<B, F>(&mut self, entity_idx: usize, bundle: B, epoch: u64, occupied: F)
+    unsafe fn write_bundle<B, F>(&mut self, entity_idx: usize, bundle: B, epoch: Epoch, occupied: F)
     where
         B: DynamicBundle,
         F: Fn(TypeId) -> bool,
@@ -797,7 +798,7 @@ impl Archetype {
     }
 
     #[inline]
-    unsafe fn write_one<T>(&mut self, entity_idx: usize, value: T, epoch: u64, occupied: bool)
+    unsafe fn write_one<T>(&mut self, entity_idx: usize, value: T, epoch: Epoch, occupied: bool)
     where
         T: Component,
     {

--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -1,0 +1,9 @@
+//! Type aliases for world epoch and component version.
+//! This aliases is created to easy adjust the epoch type size.
+
+// TODO use usize for Epoch as soon as overflow wrapping of u32 is safe and tested
+
+/// Type for world's epoch and component version.
+pub type Epoch = u64;
+/// Atomic type for world's epoch and component version.
+pub type AtomicEpoch = core::sync::atomic::AtomicU64;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ pub mod query;
 pub mod world;
 
 mod archetype;
+mod epoch;
 mod hash;
 mod idx;
 mod typeidset;

--- a/src/query/filter.rs
+++ b/src/query/filter.rs
@@ -1,6 +1,6 @@
 use core::{any::TypeId, marker::PhantomData};
 
-use crate::{archetype::Archetype, component::Component};
+use crate::{archetype::Archetype, component::Component, epoch::Epoch};
 
 /// Filters for query iterators.
 /// They affect what archetypes and entities are skipped by query iterator
@@ -8,7 +8,7 @@ use crate::{archetype::Archetype, component::Component};
 pub trait Filter {
     /// Checks if filter requires archetype to be skipped.
     #[inline]
-    fn skip_archetype(&self, archetype: &Archetype, tracks: u64, epoch: u64) -> bool {
+    fn skip_archetype(&self, archetype: &Archetype, tracks: Epoch, epoch: Epoch) -> bool {
         drop(archetype);
         drop(tracks);
         drop(epoch);
@@ -36,7 +36,7 @@ where
     T: Component,
 {
     #[inline]
-    fn skip_archetype(&self, archetype: &Archetype, tracks: u64, epoch: u64) -> bool {
+    fn skip_archetype(&self, archetype: &Archetype, tracks: Epoch, epoch: Epoch) -> bool {
         drop(tracks);
         drop(epoch);
         !archetype.contains_id(TypeId::of::<T>())
@@ -63,7 +63,7 @@ where
     T: Component,
 {
     #[inline]
-    fn skip_archetype(&self, archetype: &Archetype, tracks: u64, epoch: u64) -> bool {
+    fn skip_archetype(&self, archetype: &Archetype, tracks: Epoch, epoch: Epoch) -> bool {
         drop(tracks);
         drop(epoch);
         archetype.contains_id(TypeId::of::<T>())

--- a/src/query/option.rs
+++ b/src/query/option.rs
@@ -1,6 +1,6 @@
 use core::any::TypeId;
 
-use crate::archetype::Archetype;
+use crate::{archetype::Archetype, epoch::Epoch};
 
 use super::{Access, Fetch, ImmutableQuery, NonTrackingQuery, Query};
 
@@ -73,12 +73,16 @@ where
     }
 
     #[inline]
-    fn skip_archetype(_: &Archetype, _: u64) -> bool {
+    fn skip_archetype(_: &Archetype, _: Epoch) -> bool {
         false
     }
 
     #[inline]
-    unsafe fn fetch(archetype: &Archetype, tracks: u64, epoch: u64) -> Option<Option<T::Fetch>> {
+    unsafe fn fetch(
+        archetype: &Archetype,
+        tracks: Epoch,
+        epoch: Epoch,
+    ) -> Option<Option<T::Fetch>> {
         Some(<T as Query>::fetch(archetype, tracks, epoch))
     }
 }

--- a/src/query/read.rs
+++ b/src/query/read.rs
@@ -1,6 +1,6 @@
 use core::{any::TypeId, ptr::NonNull};
 
-use crate::{archetype::Archetype, component::Component};
+use crate::{archetype::Archetype, component::Component, epoch::Epoch};
 
 use super::{Access, Fetch, ImmutableQuery, NonTrackingQuery, Query};
 
@@ -61,12 +61,12 @@ where
     }
 
     #[inline]
-    fn skip_archetype(archetype: &Archetype, _: u64) -> bool {
+    fn skip_archetype(archetype: &Archetype, _: Epoch) -> bool {
         !archetype.contains_id(TypeId::of::<T>())
     }
 
     #[inline]
-    unsafe fn fetch(archetype: &Archetype, _tracks: u64, _epoch: u64) -> Option<FetchRead<T>> {
+    unsafe fn fetch(archetype: &Archetype, _tracks: Epoch, _epoch: Epoch) -> Option<FetchRead<T>> {
         let idx = archetype.id_index(TypeId::of::<T>())?;
         let data = archetype.data(idx);
         debug_assert_eq!(data.id, TypeId::of::<T>());

--- a/src/query/skip.rs
+++ b/src/query/skip.rs
@@ -1,6 +1,6 @@
 use core::any::TypeId;
 
-use crate::{archetype::Archetype, proof::Skip};
+use crate::{archetype::Archetype, epoch::Epoch, proof::Skip};
 
 use super::{Access, Fetch, ImmutableQuery, NonTrackingQuery, Query};
 
@@ -42,12 +42,12 @@ unsafe impl Query for Skip {
     }
 
     #[inline]
-    fn skip_archetype(_: &Archetype, _: u64) -> bool {
+    fn skip_archetype(_: &Archetype, _: Epoch) -> bool {
         false
     }
 
     #[inline]
-    unsafe fn fetch(_: &Archetype, _: u64, _epoch: u64) -> Option<Skip> {
+    unsafe fn fetch(_: &Archetype, _: Epoch, _epoch: Epoch) -> Option<Skip> {
         Some(Skip)
     }
 }

--- a/src/query/write.rs
+++ b/src/query/write.rs
@@ -1,16 +1,16 @@
 use core::{any::TypeId, ptr::NonNull};
 
-use crate::{archetype::Archetype, component::Component};
+use crate::{archetype::Archetype, component::Component, epoch::Epoch};
 
 use super::{Access, Fetch, NonTrackingQuery, Query};
 
 /// `Fetch` type for the `&mut T` query.
 #[allow(missing_debug_implementations)]
 pub struct FetchWrite<T> {
-    epoch: u64,
+    epoch: Epoch,
     ptr: NonNull<T>,
-    entity_versions: NonNull<u64>,
-    chunk_versions: NonNull<u64>,
+    entity_versions: NonNull<Epoch>,
+    chunk_versions: NonNull<Epoch>,
 }
 
 impl<'a, T> Fetch<'a> for FetchWrite<T>
@@ -79,12 +79,12 @@ where
     }
 
     #[inline]
-    fn skip_archetype(archetype: &Archetype, _: u64) -> bool {
+    fn skip_archetype(archetype: &Archetype, _: Epoch) -> bool {
         !archetype.contains_id(TypeId::of::<T>())
     }
 
     #[inline]
-    unsafe fn fetch(archetype: &Archetype, _tracks: u64, epoch: u64) -> Option<FetchWrite<T>> {
+    unsafe fn fetch(archetype: &Archetype, _tracks: Epoch, epoch: Epoch) -> Option<FetchWrite<T>> {
         let idx = archetype.id_index(TypeId::of::<T>())?;
         let data = archetype.data(idx);
         debug_assert_eq!(data.id, TypeId::of::<T>());

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -7,7 +7,7 @@ use core::{
     iter::FromIterator,
     iter::FusedIterator,
     marker::PhantomData,
-    sync::atomic::{AtomicU64, Ordering},
+    sync::atomic::Ordering,
 };
 
 use alloc::vec::Vec;
@@ -21,6 +21,7 @@ use crate::{
     bundle::{Bundle, DynamicBundle},
     component::{Component, ComponentInfo},
     entity::{Entities, EntityId},
+    epoch::{AtomicEpoch, Epoch},
     hash::{MulHasherBuilder, NoOpHasherBuilder},
     idx::MAX_IDX_USIZE,
     query::{
@@ -102,7 +103,7 @@ struct RemoveBundleInfo {
 pub struct World {
     /// Global epoch counter of the World.
     /// Incremented on each mutable query.
-    epoch: AtomicU64,
+    epoch: AtomicEpoch,
 
     /// Collection of entities with their locations.
     entities: Entities,
@@ -156,7 +157,7 @@ impl World {
     #[inline]
     pub fn new() -> Self {
         World {
-            epoch: AtomicU64::new(0),
+            epoch: AtomicEpoch::new(0),
             #[cfg(feature = "rc")]
             entities: Entities::new(1024),
             #[cfg(not(feature = "rc"))]
@@ -1149,7 +1150,7 @@ impl World {
 #[derive(Debug)]
 pub struct SpawnBatch<'a, I> {
     bundles: I,
-    epoch: u64,
+    epoch: Epoch,
     archetype_idx: u32,
     archetype: &'a mut Archetype,
     entities: &'a mut Entities,
@@ -1325,7 +1326,7 @@ where
 #[derive(Debug)]
 pub struct SpawnBatchOwned<'a, I> {
     bundles: I,
-    epoch: u64,
+    epoch: Epoch,
     archetype_idx: u32,
     archetype: &'a mut Archetype,
     entities: &'a mut Entities,
@@ -1483,7 +1484,7 @@ where
 /// Mutable query builder.
 #[derive(Debug)]
 pub struct QueryMut<'a, Q, F> {
-    epoch: &'a mut u64,
+    epoch: &'a mut Epoch,
     archetypes: &'a [Archetype],
     query: PhantomData<Q>,
     filter: F,
@@ -1601,7 +1602,7 @@ where
 /// Immutable query builder.
 #[derive(Clone, Copy, Debug)]
 pub struct QueryRef<'a, Q, F> {
-    epoch: u64,
+    epoch: Epoch,
     archetypes: &'a [Archetype],
     query: PhantomData<Q>,
     filter: F,

--- a/src/world/tracks.rs
+++ b/src/world/tracks.rs
@@ -1,10 +1,12 @@
+use crate::epoch::Epoch;
+
 /// Value to remember which modifications was already iterated over,
 /// and see what modifications are new.
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 #[allow(missing_copy_implementations)]
 #[repr(transparent)]
 pub struct Tracks {
-    pub(crate) epoch: u64,
+    pub(crate) epoch: Epoch,
 }
 
 impl Tracks {


### PR DESCRIPTION
Make possible to use ediсt in multithreaded applications.

* [x] Make World::epoch atomic;
* [x] ~~Make sure queries works as expected when the epoch overflows;~~
* [ ] Implement query_mut_unchecked, query_one_mut_unchecked, for_each_mut_unchecked, for_each_tracked_mut_unchecked, get_mut_unchecked unsafe methods for World;
* [ ] Add feature flag for `World` and `Component` `Send+Sync`.
* [ ] Optional: Add a runtime check for aliasing like hecs does by Fetch::borrow and Fetch::release;
* [ ] Optional: Use 32-bit atomic on platforms that do not support 64-bit atomics.

Resolves #1 