### PR TITLE
Fix QueryTrackedIter::fold uses 0 as tracks epoch

### DIFF
--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -634,7 +634,7 @@ where
             {
                 continue;
             }
-            if let Some(mut fetch) = unsafe { Q::fetch(archetype, 0, self.epoch) } {
+            if let Some(mut fetch) = unsafe { Q::fetch(archetype, self.tracks, self.epoch) } {
                 let entities = archetype.entities().as_ptr();
                 let mut indices = 0..archetype.len();
 


### PR DESCRIPTION
`QueryTrackedIter::fold` function always used 0 instead of the requested
component epoch value. Use the epoch value as it should.