### PR TITLE
fix without filter

### DIFF
--- a/src/query/filter.rs
+++ b/src/query/filter.rs
@@ -171,7 +171,10 @@ where
 /// Entities that match the filter are skipped.
 ///
 /// The `Not` filter will NOT cause side effects of the inner filter.
+#[derive(Clone)]
 pub struct Not<T>(pub T);
+
+unsafe impl<T> ImmutableQuery for Not<T> where T: Query {}
 
 pub struct NotFetch<T>(T, bool);
 
@@ -197,7 +200,7 @@ where
     #[inline(always)]
     unsafe fn visit_item(&mut self, idx: usize) -> bool {
         if self.1 {
-            !self.0.visit_item(idx)
+            self.0.visit_item(idx)
         } else {
             true
         }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,7 +1,7 @@
 use crate::{
     component::Component,
-    query::{DefaultQuery, Entities, ImmutableQuery, Not, With, Without},
-    relation::{related_by, ChildOf, Relation, RelationOrigin, RelationTarget},
+    query::{Entities, ImmutableQuery, Not, With, Without},
+    relation::{ChildOf, Relation, RelationOrigin, RelationTarget},
     world::{QueryOneError, World},
 };
 


### PR DESCRIPTION
Howdy, I've been messing around, and noticed there were some issues with using `QueryRef::without` which led to compilation errors and then the filter misbehaving once that was fixed. Not sure if you're going to want this because there's already the PR for the API changes already, but figured I might offer this up in case it's useful in the meantime. Cheers!