### PR TITLE
fix nostd build

### DIFF
--- a/src/entity/allocator.rs
+++ b/src/entity/allocator.rs
@@ -1,5 +1,7 @@
 use core::num::NonZeroU64;
 
+use alloc::boxed::Box;
+
 /// Range of raw entity IDs.
 /// `start` is inclusive, `end` is exclusive.
 ///

--- a/src/entity/entities.rs
+++ b/src/entity/entities.rs
@@ -3,6 +3,8 @@ use core::{
     sync::atomic::{AtomicU64, Ordering},
 };
 
+use alloc::boxed::Box;
+
 use hashbrown::{hash_map::Entry, HashMap};
 
 use crate::world::NoSuchEntity;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,8 +7,12 @@ pub use crate::{
     entity::EntityId,
     query::{Alt, Entities, Modified, PhantomQuery, Query, QueryIter},
     relation::{ChildOf, Related, Relates, RelatesExclusive, RelatesTo, Relation},
-    scheduler::Scheduler,
     system::{IntoSystem, Res, ResMut, ResMutNoSend, ResNoSync, State, System},
-    task::{task_system, task_world, Task},
     world::{EntityError, MissingComponents, NoSuchEntity, QueryOneError, QueryRef, World},
+};
+
+#[cfg(feature = "std")]
+pub use crate::{
+    scheduler::Scheduler,
+    task::{task_system, task_world, Task},
 };

--- a/src/world/builder.rs
+++ b/src/world/builder.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 
 use super::{ArchetypeSet, Edges, EpochCounter, World};
+use alloc::boxed::Box;
 
 /// Builder for [`World`] value.
 ///


### PR DESCRIPTION
Hi, this is a simple PR that fixes a couple of missing imports, and an include gate in the prelude for the scheduler and task modules, which were preventing the crate from building in no_std mode. 

Please excuse the tortured git diff, it appears our systems use different line endings and git was configured to upload files in the crlf format when you created the repo. Making git honour that on Unix is pretty much impossible, so you might want to just cherry pick the lines that have actually changed.

If continued no_std support is planned going forward it might be worth adding a CI job to check it continues to compile for no_std.

Many thanks.

- SEGFAULT / IGBC